### PR TITLE
Implement periodic data polling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY src ./src
-ENTRYPOINT ["python", "-m", "endolla_watcher.main"]
-CMD ["--file", "/data/endolla.json"]
+# Continuously fetch the dataset and render the site
+ENTRYPOINT ["python", "-m", "endolla_watcher.loop"]
+CMD ["--file", "/data/endolla.json", "--interval", "300"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 python -m endolla_watcher.main --file endolla.json --output site/index.html
+python -m endolla_watcher.loop --interval 300
 ```
 
 The site can then be served from the `site/` directory.

--- a/src/endolla_watcher/data.py
+++ b/src/endolla_watcher/data.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from typing import Any, Dict, List
 import requests
 
-ENDOLLA_URL = "https://opendata.barcelona.cat/resource/endolla.json"
+# Public download endpoint for the Endolla dataset
+ENDOLLA_URL = (
+    "https://opendata-ajuntament.barcelona.cat/data/dataset/"
+    "a2bd4c83-d024-4d78-8436-040ef996cf7f/resource/"
+    "ada4c823-9566-477d-9362-7b15e7d38189/download"
+)
 
 
 def fetch_data(path: Path | None = None) -> Dict[str, Any]:

--- a/src/endolla_watcher/loop.py
+++ b/src/endolla_watcher/loop.py
@@ -1,0 +1,36 @@
+import argparse
+import time
+from pathlib import Path
+from .data import fetch_data, parse_usage
+from .analyze import analyze
+from .render import render
+
+
+def run_once(output: Path, file: Path | None = None) -> None:
+    data = fetch_data(file)
+    records = parse_usage(data)
+    problematic = analyze(records)
+    html = render(problematic)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(html, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("site/index.html"))
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=300,
+        help="Seconds between updates"
+    )
+    args = parser.parse_args()
+
+    while True:
+        run_once(args.output, args.file)
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -7,8 +7,8 @@ HTML_TEMPLATE = """
     <meta charset='UTF-8'>
     <title>Endolla Watcher</title>
     <style>
-        table {border-collapse: collapse;}
-        th, td {border: 1px solid #ccc; padding: 4px;}
+        table {{border-collapse: collapse;}}
+        th, td {{border: 1px solid #ccc; padding: 4px;}}
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- update dataset URL to the official download link
- escape braces in `render` HTML template
- add `loop.py` for continuous polling every few minutes
- update Dockerfile to use the polling module
- document usage of the new loop script

## Testing
- `python -m endolla_watcher.main --file endolla.json --output site/index.html`
- `python -m endolla_watcher.loop --file endolla.json --output site/index.html --interval 1`

------
https://chatgpt.com/codex/tasks/task_e_6880d5daed488332b5a24a814763c082