### PR TITLE
Fix editable install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[metadata]
+name = endolla-watcher
+version = 0.1.0
+description = Monitor Endolla dataset for underused chargers
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+packages = find:
+package_dir =
+    = src
+python_requires = >=3.11
+install_requires =
+    requests>=2.0
+
+[options.packages.find]
+where = src

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- add classic `setup.cfg` and `setup.py` to support `pip install -e .` on older
  pip versions

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6880e251eed8833288706e7710736dc4