### PR TITLE
Add sqlite history tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 python -m endolla_watcher.main --file endolla.json --output site/index.html
-python -m endolla_watcher.loop --interval 300
+python -m endolla_watcher.loop --interval 300 --db endolla.db
 ```
 
 The site can then be served from the `site/` directory.
@@ -21,7 +21,9 @@ The site can then be served from the `site/` directory.
 
 ```
 docker build -t endolla-watcher .
-docker run -v $(pwd)/endolla.json:/data/endolla.json endolla-watcher
+docker run -v $(pwd)/endolla.json:/data/endolla.json \
+           -v $(pwd)/endolla.db:/data/endolla.db \
+           endolla-watcher
 ```
 
 ## Automation

--- a/src/endolla_watcher/storage.py
+++ b/src/endolla_watcher/storage.py
@@ -1,0 +1,106 @@
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS port_status (
+    ts TEXT NOT NULL,
+    location_id TEXT,
+    station_id TEXT,
+    port_id TEXT,
+    status TEXT,
+    last_updated TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_port_ts ON port_status(location_id, station_id, port_id, ts);
+"""
+
+PortKey = Tuple[str | None, str | None, str | None]
+
+
+def connect(path: Path) -> sqlite3.Connection:
+    """Open connection and ensure schema exists."""
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA)
+    return conn
+
+
+def save_snapshot(conn: sqlite3.Connection, records: Iterable[Dict[str, Any]], ts: datetime | None = None) -> None:
+    """Persist a snapshot of all port statuses."""
+    if ts is None:
+        ts = datetime.now().astimezone()
+    rows = [
+        (
+            ts.isoformat(),
+            r.get("location_id"),
+            r.get("station_id"),
+            r.get("port_id"),
+            r.get("status"),
+            r.get("last_updated"),
+        )
+        for r in records
+    ]
+    conn.executemany(
+        "INSERT INTO port_status (ts, location_id, station_id, port_id, status, last_updated) VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+
+def _session_durations(statuses: List[Tuple[datetime, str]]) -> List[float]:
+    """Return session durations in minutes from a status timeline."""
+    sessions: List[float] = []
+    start: datetime | None = None
+    for ts, status in statuses:
+        if status == "IN_USE":
+            if start is None:
+                start = ts
+        else:
+            if start is not None:
+                sessions.append((ts - start).total_seconds() / 60)
+                start = None
+    return sessions
+
+
+def recent_sessions(conn: sqlite3.Connection, since: datetime) -> Dict[PortKey, List[float]]:
+    """Get session durations for each port since a given time."""
+    cur = conn.execute(
+        "SELECT location_id, station_id, port_id, ts, status FROM port_status WHERE ts >= ? ORDER BY location_id, station_id, port_id, ts",
+        (since.isoformat(),),
+    )
+    history: Dict[PortKey, List[Tuple[datetime, str]]] = {}
+    for loc, sta, port, ts, status in cur:
+        key = (loc, sta, port)
+        history.setdefault(key, []).append((datetime.fromisoformat(ts), status))
+    return {k: _session_durations(v) for k, v in history.items()}
+
+
+def analyze_recent(conn: sqlite3.Connection, days: int = 7, short_threshold: int = 3) -> List[Dict[str, Any]]:
+    """Return problematic chargers based on recent history."""
+    since = datetime.now().astimezone() - timedelta(days=days)
+    sessions = recent_sessions(conn, since)
+    problematic: List[Dict[str, Any]] = []
+    for (loc, sta, port), durs in sessions.items():
+        if not durs:
+            problematic.append(
+                {
+                    "location_id": loc,
+                    "station_id": sta,
+                    "port_id": port,
+                    "status": None,
+                    "reason": "no sessions",
+                }
+            )
+            continue
+        short = [d for d in durs if d < short_threshold]
+        if short:
+            problematic.append(
+                {
+                    "location_id": loc,
+                    "station_id": sta,
+                    "port_id": port,
+                    "status": None,
+                    "reason": f"short sessions: {len(short)}",
+                }
+            )
+    return problematic


### PR DESCRIPTION
## Summary
- store dataset snapshots in a SQLite DB
- report problematic chargers from historical data
- update loop command to use the DB
- document DB usage in README

## Testing
- `pip install -e .`
- `python -m endolla_watcher.loop --help`
- `python - <<'PY'
from endolla_watcher.loop import run_once
from pathlib import Path
run_once(Path('out.html'), Path('endolla.json'), Path('test.db'))
print('done')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6880ec80a430833284c5d576517b9fb6