### PR TITLE
Add comprehensive logging

### DIFF
--- a/src/endolla_watcher/analyze.py
+++ b/src/endolla_watcher/analyze.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta
 from typing import Dict, List
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 SHORT_SESSION_THRESHOLD_MIN = 3
@@ -11,6 +14,8 @@ def analyze(records: List[Dict[str, any]]) -> List[Dict[str, any]]:
     problematic: List[Dict[str, any]] = []
     now = datetime.now().astimezone()
 
+    logger.debug("Analyzing %d records", len(records))
+
     for r in records:
         sessions = r.get("sessions", [])
         if sessions:
@@ -18,6 +23,9 @@ def analyze(records: List[Dict[str, any]]) -> List[Dict[str, any]]:
             if short_sessions:
                 r["reason"] = f"short sessions: {len(short_sessions)}"
                 problematic.append(r)
+                logger.debug(
+                    "Port %s has %d short sessions", r.get("port_id"), len(short_sessions)
+                )
                 continue
         else:
             last = r.get("last_updated")
@@ -29,5 +37,9 @@ def analyze(records: List[Dict[str, any]]) -> List[Dict[str, any]]:
                 if last_time and now - last_time > timedelta(days=INACTIVE_DAYS_THRESHOLD):
                     r["reason"] = "no sessions"
                     problematic.append(r)
+                    logger.debug(
+                        "Port %s inactive since %s", r.get("port_id"), last_time
+                    )
         
+    logger.debug("Identified %d problematic ports", len(problematic))
     return problematic

--- a/src/endolla_watcher/data.py
+++ b/src/endolla_watcher/data.py
@@ -1,7 +1,10 @@
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict, List
 import requests
+
+logger = logging.getLogger(__name__)
 
 # Public download endpoint for the Endolla dataset
 ENDOLLA_URL = (
@@ -14,10 +17,15 @@ ENDOLLA_URL = (
 def fetch_data(path: Path | None = None) -> Dict[str, Any]:
     """Fetch dataset either from local file or remote endpoint."""
     if path:
+        logger.debug("Loading dataset from %s", path)
         with path.open() as f:
-            return json.load(f)
+            data = json.load(f)
+        logger.debug("Loaded %d bytes from file", len(json.dumps(data)))
+        return data
+    logger.debug("Fetching dataset from %s", ENDOLLA_URL)
     resp = requests.get(ENDOLLA_URL, timeout=30)
     resp.raise_for_status()
+    logger.debug("Fetched %d bytes from remote", len(resp.content))
     return resp.json()
 
 
@@ -38,4 +46,5 @@ def parse_usage(data: Dict[str, Any]) -> List[Dict[str, Any]]:
                 if "sessions" in port:
                     item["sessions"] = port["sessions"]
                 results.append(item)
+    logger.debug("Parsed %d port records", len(results))
     return results

--- a/src/endolla_watcher/logging_utils.py
+++ b/src/endolla_watcher/logging_utils.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def setup_logging(debug: bool = False) -> None:
+    """Configure basic logging for the application."""
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )

--- a/src/endolla_watcher/loop.py
+++ b/src/endolla_watcher/loop.py
@@ -1,15 +1,21 @@
 import argparse
 import time
+import logging
 from pathlib import Path
 from .data import fetch_data, parse_usage
 from .analyze import analyze
 from .render import render
 from . import storage
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def run_once(output: Path, file: Path | None = None, db: Path | None = None) -> None:
+    logger.debug("Running update with file=%s db=%s", file, db)
     data = fetch_data(file)
     records = parse_usage(data)
+    logger.debug("Fetched %d records", len(records))
     if db:
         conn = storage.connect(db)
         storage.save_snapshot(conn, records)
@@ -20,6 +26,7 @@ def run_once(output: Path, file: Path | None = None, db: Path | None = None) -> 
     html = render(problematic)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(html, encoding="utf-8")
+    logger.debug("Wrote output to %s", output)
 
 
 def main() -> None:
@@ -31,12 +38,21 @@ def main() -> None:
         "--interval",
         type=int,
         default=300,
-        help="Seconds between updates"
+        help="Seconds between updates",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
     )
     args = parser.parse_args()
 
+    setup_logging(args.debug)
+
     while True:
+        logger.info("Starting update cycle")
         run_once(args.output, args.file, args.db)
+        logger.info("Sleeping for %s seconds", args.interval)
         time.sleep(args.interval)
 
 

--- a/src/endolla_watcher/main.py
+++ b/src/endolla_watcher/main.py
@@ -1,17 +1,29 @@
 import argparse
+import logging
 from pathlib import Path
 
 from .data import fetch_data, parse_usage
 from .analyze import analyze
 from .render import render
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--file", type=Path, help="Local JSON file to parse")
     parser.add_argument("--output", type=Path, default=Path("site/index.html"))
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
     args = parser.parse_args()
 
+    setup_logging(args.debug)
+
+    logger.info("Reading data")
     data = fetch_data(args.file)
     records = parse_usage(data)
     problematic = analyze(records)
@@ -19,6 +31,7 @@ def main() -> None:
     html = render(problematic)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(html, encoding="utf-8")
+    logger.info("Wrote report to %s", args.output)
 
 
 if __name__ == "__main__":

--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -1,4 +1,7 @@
 from typing import List, Dict
+import logging
+
+logger = logging.getLogger(__name__)
 
 HTML_TEMPLATE = """
 <!DOCTYPE html>
@@ -27,10 +30,13 @@ HTML_TEMPLATE = """
 
 
 def render(problematic: List[Dict[str, any]]) -> str:
+    logger.debug("Rendering %d problematic ports", len(problematic))
     rows = []
     for r in problematic:
         row = "<tr>" + "".join(
             f"<td>{r.get(k,'')}</td>" for k in ["location_id","station_id","port_id","status","reason"]
         ) + "</tr>"
         rows.append(row)
-    return HTML_TEMPLATE.format(rows="\n".join(rows))
+    html = HTML_TEMPLATE.format(rows="\n".join(rows))
+    logger.debug("Generated HTML with %d rows", len(rows))
+    return html


### PR DESCRIPTION
## Summary
- add `logging_utils` with setup helper
- add debug logging to data parsing and fetching
- log analysis decisions
- log output generation and update cycle
- expose `--debug` flag for CLI tools

## Testing
- `pip install -e .`
- `python -m endolla_watcher.main --file endolla.json --output site/index.html --debug | tail -n 5`
- `python -m endolla_watcher.loop --file endolla.json --output site/index.html --debug --interval 1 --db endolla.db | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6880f15023bc8332a4ce844a13c989ef