### PR TITLE
Add charger analysis ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ source venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 python -m endolla_watcher.main --file endolla.json --output site/index.html
-python -m endolla_watcher.loop --interval 300 --db endolla.db
+python -m endolla_watcher.loop --interval 300 --db endolla.db \
+    --unused-days 4 --long-session-days 2 --long-session-min 5 \
+    --unavailable-hours 24
 ```
 
 The site can then be served from the `site/` directory.

--- a/src/endolla_watcher/loop.py
+++ b/src/endolla_watcher/loop.py
@@ -6,12 +6,18 @@ from .data import fetch_data, parse_usage
 from .analyze import analyze
 from .render import render
 from . import storage
+from .rules import Rules
 from .logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
 
-def run_once(output: Path, file: Path | None = None, db: Path | None = None) -> None:
+def run_once(
+    output: Path,
+    file: Path | None = None,
+    db: Path | None = None,
+    rules: Rules | None = None,
+) -> None:
     logger.debug("Running update with file=%s db=%s", file, db)
     data = fetch_data(file)
     records = parse_usage(data)
@@ -19,7 +25,7 @@ def run_once(output: Path, file: Path | None = None, db: Path | None = None) -> 
     if db:
         conn = storage.connect(db)
         storage.save_snapshot(conn, records)
-        problematic = storage.analyze_recent(conn)
+        problematic = storage.analyze_chargers(conn, rules)
         conn.close()
     else:
         problematic = analyze(records)
@@ -40,6 +46,10 @@ def main() -> None:
         default=300,
         help="Seconds between updates",
     )
+    parser.add_argument("--unused-days", type=int, default=4)
+    parser.add_argument("--long-session-days", type=int, default=2)
+    parser.add_argument("--long-session-min", type=int, default=5)
+    parser.add_argument("--unavailable-hours", type=int, default=24)
     parser.add_argument(
         "--debug",
         action="store_true",
@@ -49,9 +59,16 @@ def main() -> None:
 
     setup_logging(args.debug)
 
+    rules = Rules(
+        unused_days=args.unused_days,
+        long_session_days=args.long_session_days,
+        long_session_min=args.long_session_min,
+        unavailable_hours=args.unavailable_hours,
+    )
+
     while True:
         logger.info("Starting update cycle")
-        run_once(args.output, args.file, args.db)
+        run_once(args.output, args.file, args.db, rules)
         logger.info("Sleeping for %s seconds", args.interval)
         time.sleep(args.interval)
 

--- a/src/endolla_watcher/rules.py
+++ b/src/endolla_watcher/rules.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class Rules:
+    """Configuration for detecting problematic chargers."""
+
+    # Days with no port usage to consider a charger unused
+    unused_days: int = 4
+    # Past window to look for long sessions
+    long_session_days: int = 2
+    # Minimum duration of a session to count as long (minutes)
+    long_session_min: int = 5
+    # Continuous hours with all ports unavailable
+    unavailable_hours: int = 24

--- a/src/endolla_watcher/storage.py
+++ b/src/endolla_watcher/storage.py
@@ -2,6 +2,7 @@ import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
+from .rules import Rules
 import logging
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,8 @@ CREATE TABLE IF NOT EXISTS port_status (
 );
 CREATE INDEX IF NOT EXISTS idx_port_ts ON port_status(location_id, station_id, port_id, ts);
 """
+
+UNAVAILABLE_STATUSES = {"OUT_OF_ORDER", "UNAVAILABLE"}
 
 PortKey = Tuple[str | None, str | None, str | None]
 
@@ -69,6 +72,23 @@ def _session_durations(statuses: List[Tuple[datetime, str]]) -> List[float]:
     return sessions
 
 
+def _recent_status_history(
+    conn: sqlite3.Connection, since: datetime
+) -> Dict[PortKey, List[Tuple[datetime, str]]]:
+    """Return status history for each port since a given time."""
+    logger.debug("Fetching status history since %s", since)
+    cur = conn.execute(
+        "SELECT location_id, station_id, port_id, ts, status FROM port_status WHERE ts >= ? ORDER BY location_id, station_id, port_id, ts",
+        (since.isoformat(),),
+    )
+    history: Dict[PortKey, List[Tuple[datetime, str]]] = {}
+    for loc, sta, port, ts, status in cur:
+        key = (loc, sta, port)
+        history.setdefault(key, []).append((datetime.fromisoformat(ts), status))
+    logger.debug("Loaded status history for %d ports", len(history))
+    return history
+
+
 def recent_sessions(conn: sqlite3.Connection, since: datetime) -> Dict[PortKey, List[float]]:
     """Get session durations for each port since a given time."""
     logger.debug("Fetching sessions since %s", since)
@@ -117,4 +137,74 @@ def analyze_recent(conn: sqlite3.Connection, days: int = 7, short_threshold: int
             )
             logger.debug("Port %s has %d short sessions", port, len(short))
     logger.debug("Identified %d problematic ports", len(problematic))
+    return problematic
+
+
+def analyze_chargers(conn: sqlite3.Connection, rules: Rules | None = None) -> List[Dict[str, Any]]:
+    """Classify chargers as problematic based on configurable rules."""
+    if rules is None:
+        rules = Rules()
+
+    now = datetime.now().astimezone()
+    earliest = now - timedelta(
+        days=max(rules.unused_days, rules.long_session_days, rules.unavailable_hours / 24)
+    )
+    history = _recent_status_history(conn, earliest)
+
+    # Organize data per station
+    stations: Dict[Tuple[str | None, str | None], Dict[str | None, List[Tuple[datetime, str]]]] = {}
+    for (loc, sta, port), events in history.items():
+        stations.setdefault((loc, sta), {})[port] = events
+
+    problematic: List[Dict[str, Any]] = []
+    for (loc, sta), ports in stations.items():
+        reasons: List[str] = []
+
+        # Rule 1: no usage for more than N days
+        since_unused = now - timedelta(days=rules.unused_days)
+        used_recently = any(
+            any(status == "IN_USE" and ts >= since_unused for ts, status in events)
+            for events in ports.values()
+        )
+        if not used_recently:
+            reasons.append(f"unused > {rules.unused_days}d")
+
+        # Rule 2: no long sessions in past window
+        since_long = now - timedelta(days=rules.long_session_days)
+        has_long = any(
+            any(
+                d >= rules.long_session_min
+                for d in _session_durations([(ts, st) for ts, st in events if ts >= since_long])
+            )
+            for events in ports.values()
+        )
+        if not has_long:
+            reasons.append(
+                f"no session >= {rules.long_session_min}min in {rules.long_session_days}d"
+            )
+
+        # Rule 3: all ports unavailable for continuous hours
+        since_unavail = now - timedelta(hours=rules.unavailable_hours)
+        all_unavail = all(
+            all(
+                status in UNAVAILABLE_STATUSES for ts, status in events if ts >= since_unavail
+            )
+            and any(ts >= since_unavail for ts, _ in events)
+            for events in ports.values()
+        )
+        if all_unavail and ports:
+            reasons.append(f"unavailable > {rules.unavailable_hours}h")
+
+        if reasons:
+            problematic.append(
+                {
+                    "location_id": loc,
+                    "station_id": sta,
+                    "port_id": None,
+                    "status": None,
+                    "reason": ", ".join(reasons),
+                }
+            )
+
+    logger.debug("Identified %d problematic chargers", len(problematic))
     return problematic


### PR DESCRIPTION
## Summary
- create `Rules` dataclass with thresholds
- implement `analyze_chargers` in `storage.py` using the rules
- allow CLI configuration of rules in `loop.py`
- document new arguments in README

## Testing
- `python -m pip install -e .`
- `python -m endolla_watcher.loop --help`

------
https://chatgpt.com/codex/tasks/task_e_6880f3e1d34c8332aed0cd083b669dad