### PR TITLE
Improve logging for healthy chargers

### DIFF
--- a/src/endolla_watcher/analyze.py
+++ b/src/endolla_watcher/analyze.py
@@ -40,6 +40,10 @@ def analyze(records: List[Dict[str, any]]) -> List[Dict[str, any]]:
                     logger.debug(
                         "Port %s inactive since %s", r.get("port_id"), last_time
                     )
+                    continue
+
+        if "reason" not in r:
+            logger.debug("Port %s is healthy", r.get("port_id"))
         
     logger.debug("Identified %d problematic ports", len(problematic))
     return problematic

--- a/src/endolla_watcher/storage.py
+++ b/src/endolla_watcher/storage.py
@@ -136,6 +136,10 @@ def analyze_recent(conn: sqlite3.Connection, days: int = 7, short_threshold: int
                 }
             )
             logger.debug("Port %s has %d short sessions", port, len(short))
+            continue
+
+        logger.debug("Port %s is healthy", port)
+
     logger.debug("Identified %d problematic ports", len(problematic))
     return problematic
 
@@ -205,6 +209,8 @@ def analyze_chargers(conn: sqlite3.Connection, rules: Rules | None = None) -> Li
                     "reason": ", ".join(reasons),
                 }
             )
+        else:
+            logger.debug("Charger %s/%s is healthy", loc, sta)
 
     logger.debug("Identified %d problematic chargers", len(problematic))
     return problematic


### PR DESCRIPTION
## Summary
- add debug logs in `analyze()` and `storage` helpers when a port or charger is healthy
- explain port/status values absent due to station-level analysis

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880f778b01c8332bdab1119e9d787f7