### PR TITLE
Introduce separate fetch and update loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ This project monitors the Barcelona Endolla open data to find underused or out-o
 - Prefer Python for scraping and analysis.
 - Keep dependencies minimal and list them in `requirements.txt`.
 - Docker support is expected for local development and CI.
+
+## TODO
+- Dockerise the loop functionality so it can run unattended.
+- Create a script to push the updated site via git on a schedule.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ source venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 python -m endolla_watcher.main --file endolla.json --output site/index.html
-python -m endolla_watcher.loop --interval 300 --db endolla.db \
-    --unused-days 4 --long-session-days 2 --long-session-min 5 \
-    --unavailable-hours 24
+python -m endolla_watcher.loop --fetch-interval 60 --update-interval 3600 \
+    --db endolla.db --unused-days 4 --long-session-days 2 \
+    --long-session-min 5 --unavailable-hours 24
 ```
 
 The site can then be served from the `site/` directory.


### PR DESCRIPTION
## Summary
- split loop into `fetch_once` and `update_once`
- allow different fetch and update intervals
- document the new CLI arguments
- list upcoming tasks in AGENTS.md

## Testing
- `python -m endolla_watcher.loop --help`

------
https://chatgpt.com/codex/tasks/task_e_68810f38f1ac8332809a557d17c47b5d