### PR TITLE
Implement Dockerized loop defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,13 @@ COPY src ./src
 RUN pip install .
 # Continuously fetch the dataset and render the site
 ENTRYPOINT ["python", "-m", "endolla_watcher.loop"]
-CMD ["--file", "/data/endolla.json", "--interval", "300"]
+# Default to fetching the dataset every five minutes and updating the report
+# hourly. Data and generated site files live under /data so they can be
+# persisted via a volume when running the container.
+CMD [
+    "--file", "/data/endolla.json",
+    "--output", "/data/site/index.html",
+    "--db", "/data/endolla.db",
+    "--fetch-interval", "300",
+    "--update-interval", "3600"
+]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ The site can then be served from the `site/` directory.
 docker build -t endolla-watcher .
 docker run -v $(pwd)/endolla.json:/data/endolla.json \
            -v $(pwd)/endolla.db:/data/endolla.db \
-           endolla-watcher
+           -v $(pwd)/site:/data/site \
+           endolla-watcher \
+           --fetch-interval 300 --update-interval 3600
 ```
 
 ## Automation


### PR DESCRIPTION
## Summary
- update Dockerfile to use new loop CLI parameters
- mount output directory and database via volume
- document Docker run command with volume mounts and example fetch/update intervals

## Testing
- `python -m pip install -e .`
- `python -m endolla_watcher.main --help`
- `python -m endolla_watcher.loop --help`


------
https://chatgpt.com/codex/tasks/task_e_688110bbd3488332937407d10d0cdeac