### PR TITLE
Enable DockerHub build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/endolla-watcher:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
 FROM python:3.11-slim
 WORKDIR /app
+
 COPY requirements.txt pyproject.toml ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+# Install git so the push_site.py helper can run inside the container
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY src ./src
-RUN pip install .
+COPY scripts/push_site.py /usr/local/bin/push_site.py
+RUN chmod +x /usr/local/bin/push_site.py && \
+    pip install .
 # Continuously fetch the dataset and render the site
 ENTRYPOINT ["python", "-m", "endolla_watcher.loop"]
 # Default to fetching the dataset every five minutes and updating the report

--- a/README.md
+++ b/README.md
@@ -30,10 +30,17 @@ docker run -v $(pwd)/endolla.json:/data/endolla.json \
            --fetch-interval 300 --update-interval 3600
 ```
 
+The image contains `git` and the `push_site.py` helper so updates can be
+published directly from within the container.
+
 ## Automation
 
 GitHub Actions (`.github/workflows/update.yml`) periodically runs the watcher
 and deploys the generated HTML to the `gh-pages` branch.
+
+A second workflow (`.github/workflows/docker.yml`) builds the Docker image and
+pushes it to Docker Hub. Configure the `DOCKERHUB_USERNAME` and
+`DOCKERHUB_TOKEN` secrets for authentication.
 
 For local deployments, the `scripts/push_site.py` helper commits the contents of
 the `site/` directory to the `gh-pages` branch and pushes the update. It can be


### PR DESCRIPTION
## Summary
- install Git and helper script in container
- add workflow to publish Docker image to DockerHub
- document DockerHub workflow and container push helper

## Testing
- `python -m py_compile scripts/push_site.py`
- `python -m pip install -e .[dev]`


------
https://chatgpt.com/codex/tasks/task_e_688113e9336c83328958f125bb76f2a3