### PR TITLE
Fix Dockerfile CMD syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ ENTRYPOINT ["python", "-m", "endolla_watcher.loop"]
 # Default to fetching the dataset every five minutes and updating the report
 # hourly. Data and generated site files live under /data so they can be
 # persisted via a volume when running the container.
-CMD [
-    "--file", "/data/endolla.json",
-    "--output", "/data/site/index.html",
-    "--db", "/data/endolla.db",
-    "--fetch-interval", "300",
-    "--update-interval", "3600"
+CMD [ \
+    "--file", "/data/endolla.json", \
+    "--output", "/data/site/index.html", \
+    "--db", "/data/endolla.db", \
+    "--fetch-interval", "300", \
+    "--update-interval", "3600" \
 ]


### PR DESCRIPTION
## Summary
- fix CMD syntax in `Dockerfile`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688115fc814c8332bac802e005167d6d