### PR TITLE
Fix push_site branch handling

### DIFF
--- a/scripts/push_site.py
+++ b/scripts/push_site.py
@@ -35,7 +35,12 @@ def main() -> None:
         repo_url = repo_url.replace('https://', f'https://{token}@')
 
     run('git', 'clone', repo_url, str(tmpdir))
-    run('git', 'checkout', '-B', args.branch, cwd=tmpdir)
+    fetch = subprocess.run(['git', 'fetch', args.remote, args.branch], cwd=tmpdir)
+    if fetch.returncode == 0:
+        run('git', 'checkout', '-B', args.branch, f'{args.remote}/{args.branch}',
+            cwd=tmpdir)
+    else:
+        run('git', 'checkout', '--orphan', args.branch, cwd=tmpdir)
     if os.environ.get('GH_NAME'):
         run('git', 'config', 'user.name', os.environ['GH_NAME'], cwd=tmpdir)
     if os.environ.get('GH_EMAIL'):


### PR DESCRIPTION
## Summary
- base temporary `gh-pages` branch on the remote before committing site updates

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_6881d8ac5dc48332b75fe11df2c79aa2