### PR TITLE
Fix Docker entrypoint defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,18 @@ COPY scripts/push_site.py /usr/local/bin/push_site.py
 RUN chmod +x /usr/local/bin/push_site.py && \
     pip install .
 # Continuously fetch the dataset and render the site
-ENTRYPOINT ["python", "-m", "endolla_watcher.loop"]
-# Default to fetching the dataset every five minutes and updating the report
-# hourly. Data and generated site files live under /data so they can be
-# persisted via a volume when running the container.
-CMD [ \
-    "--file", "/data/endolla.json", \
-    "--output", "/data/site/index.html", \
-    "--db", "/data/endolla.db", \
-    "--fetch-interval", "300", \
-    "--update-interval", "3600" \
+# Always write the dataset and generated site under /data so volumes can
+# persist them. Additional arguments provided to `docker run` will be appended
+# allowing the defaults here to be overridden if needed.
+ENTRYPOINT [
+    "python", "-m", "endolla_watcher.loop",
+    "--file", "/data/endolla.json",
+    "--output", "/data/site/index.html",
+    "--db", "/data/endolla.db"
+]
+# Default intervals can be replaced by passing arguments when running the
+# container.
+CMD [
+    "--fetch-interval", "300",
+    "--update-interval", "3600"
 ]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ docker run -v $(pwd)/endolla.json:/data/endolla.json \
            --push-site
 ```
 
+The entrypoint already sets the `--file`, `--output` and `--db` options to use
+`/data` inside the container. Any arguments provided when running the image are
+appended to those defaults, so you only need to specify the options you wish to
+change, such as the fetch interval or `--push-site`.
+
 The image contains `git` and the `push_site.py` helper so updates can be
 published directly from within the container. Provide the GitHub token and
 repository URL as shown above to enable automatic pushes.


### PR DESCRIPTION
## Summary
- keep default `/data` paths when running the Docker image
- document how runtime arguments are appended to the defaults

## Testing
- `python -m pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6881de71cd90833284a6492c605c8459