### PR TITLE
Add themed frontend with About page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ python -m endolla_watcher.loop --fetch-interval 60 --update-interval 3600 \
     --long-session-min 5 --unavailable-hours 24
 ```
 
-The site can then be served from the `site/` directory.
+The site can then be served from the `site/` directory. It now features a small
+Bootstrap-based theme and an `about.html` page with project details.
 
 ## Docker
 

--- a/src/endolla_watcher/loop.py
+++ b/src/endolla_watcher/loop.py
@@ -5,7 +5,7 @@ import time
 import logging
 from pathlib import Path
 from .data import fetch_data, parse_usage
-from .render import render
+from .render import render, render_about
 from . import storage
 from .rules import Rules
 from .logging_utils import setup_logging
@@ -34,6 +34,8 @@ def update_once(output: Path, db: Path, rules: Rules | None = None) -> None:
     html = render(problematic, stats)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(html, encoding="utf-8")
+    about_path = output.parent / "about.html"
+    about_path.write_text(render_about(), encoding="utf-8")
     logger.debug("Wrote output to %s", output)
 
 

--- a/src/endolla_watcher/main.py
+++ b/src/endolla_watcher/main.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from .data import fetch_data, parse_usage
 from .analyze import analyze
-from .render import render
+from .render import render, render_about
 from .stats import from_records
 from .logging_utils import setup_logging
 
@@ -33,6 +33,9 @@ def main() -> None:
     html = render(problematic, stats)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(html, encoding="utf-8")
+    # Write the about page alongside the main report
+    about_path = args.output.parent / "about.html"
+    about_path.write_text(render_about(), encoding="utf-8")
     logger.info("Wrote report to %s", args.output)
 
 

--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -3,49 +3,93 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-HTML_TEMPLATE = """
+
+# Navigation bar shared across pages
+NAVBAR = """
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Endolla Watcher</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+"""
+
+# Template for the main index page
+INDEX_TEMPLATE = """
 <!DOCTYPE html>
 <html lang='en'>
 <head>
     <meta charset='UTF-8'>
     <title>Endolla Watcher</title>
-    <style>
-        table {{border-collapse: collapse;}}
-        th, td {{border: 1px solid #ccc; padding: 4px;}}
-    </style>
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-<h1>Statistics</h1>
-<ul>
-    <li>Total chargers: {chargers}</li>
-    <li>Unavailable chargers: {unavailable}</li>
-    <li>Currently charging: {charging}</li>
-    <li>Total charging events: {sessions}</li>
+{navbar}
+<div class="container py-4">
+<h1 class="mb-4">Network Overview</h1>
+<ul class="list-group mb-4">
+    <li class="list-group-item">Total chargers: {chargers}</li>
+    <li class="list-group-item">Unavailable chargers: {unavailable}</li>
+    <li class="list-group-item">Currently charging: {charging}</li>
+    <li class="list-group-item">Total charging events: {sessions}</li>
 </ul>
-<h1>Problematic Chargers</h1>
-<table>
-    <thead>
+<h2 class="mt-4">Problematic Chargers</h2>
+<div class="table-responsive">
+<table class="table table-striped">
+    <thead class="table-dark">
         <tr><th>Location</th><th>Station</th><th>Port</th><th>Status</th><th>Reason</th></tr>
     </thead>
     <tbody>
         {rows}
     </tbody>
 </table>
+</div>
+</div>
+</body>
+</html>
+"""
+
+# Template for the about page
+ABOUT_TEMPLATE = """
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <title>About - Endolla Watcher</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+{navbar}
+<div class="container py-4">
+<h1>About Endolla Watcher</h1>
+<p>Endolla Watcher keeps an eye on Barcelona's public charging network. It highlights stations that appear inactive or unavailable so issues can be resolved quickly.</p>
+<p>This project is built and maintained by <strong>dewgenenny</strong>, an electric vehicle and data enthusiast eager to optimise infrastructure through better information.</p>
+</div>
 </body>
 </html>
 """
 
 
 def render(problematic: List[Dict[str, any]], stats: Dict[str, int] | None = None) -> str:
+    """Return the HTML for the main report page."""
     logger.debug("Rendering %d problematic ports", len(problematic))
     if stats is None:
         stats = {"chargers": 0, "unavailable": 0, "charging": 0, "sessions": 0}
     rows = []
     for r in problematic:
         row = "<tr>" + "".join(
-            f"<td>{r.get(k,'')}</td>" for k in ["location_id","station_id","port_id","status","reason"]
+            f"<td>{r.get(k,'')}</td>" for k in ["location_id", "station_id", "port_id", "status", "reason"]
         ) + "</tr>"
         rows.append(row)
-    html = HTML_TEMPLATE.format(rows="\n".join(rows), **stats)
+    html = INDEX_TEMPLATE.format(rows="\n".join(rows), navbar=NAVBAR, **stats)
     logger.debug("Generated HTML with %d rows", len(rows))
     return html
+
+
+def render_about() -> str:
+    """Return the HTML for the about page."""
+    return ABOUT_TEMPLATE.format(navbar=NAVBAR)


### PR DESCRIPTION
## Summary
- modernize HTML output with a Bootstrap-based layout
- add a new About page generated alongside index.html
- mention the new theme in the README

## Testing
- `python -m pip install -e .`
- `python -m endolla_watcher.main --file endolla.json --output site/index.html`
- `python - <<'EOF'
from pathlib import Path
from endolla_watcher.loop import update_once, Rules
update_once(Path('site/test_index.html'), Path('endolla.db'), Rules())
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881edcb931883329575b6da804d52cf