### PR TITLE
Fix docker entrypoint to fetch remote data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +x /usr/local/bin/push_site.py && \
 # Always write the dataset and generated site under /data so volumes can
 # persist them. Additional arguments provided to `docker run` will be appended
 # allowing the defaults here to be overridden if needed.
-ENTRYPOINT ["python", "-m", "endolla_watcher.loop", "--file", "/data/endolla.json", "--output", "/data/site/index.html", "--db", "/data/endolla.db"]
+ENTRYPOINT ["python", "-m", "endolla_watcher.loop", "--output", "/data/site/index.html", "--db", "/data/endolla.db"]
 # Default intervals can be replaced by passing arguments when running the
 # container.
 CMD ["--fetch-interval", "300", "--update-interval", "3600"]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Bootstrap-based theme and an `about.html` page with project details.
 
 ```
 docker build -t endolla-watcher .
-docker run -v $(pwd)/endolla.json:/data/endolla.json \
-           -v $(pwd)/endolla.db:/data/endolla.db \
+docker run -v $(pwd)/endolla.db:/data/endolla.db \
            -v $(pwd)/site:/data/site \
            -e GH_TOKEN=YOURTOKEN \
            -e REPO_URL=https://github.com/you/repo.git \
@@ -36,10 +35,12 @@ docker run -v $(pwd)/endolla.json:/data/endolla.json \
            --push-site
 ```
 
-The entrypoint already sets the `--file`, `--output` and `--db` options to use
-`/data` inside the container. Any arguments provided when running the image are
-appended to those defaults, so you only need to specify the options you wish to
-change, such as the fetch interval or `--push-site`.
+The entrypoint fetches the dataset from the public API and sets the `--output`
+and `--db` paths under `/data`. Any arguments provided when running the image
+are appended to those defaults, so you only need to specify the options you wish
+to change, such as the fetch interval or `--push-site`. To analyse a specific
+dataset file instead of the live data, start the container with
+`--file /path/to/file`.
 
 The image contains `git` and the `push_site.py` helper so updates can be
 published directly from within the container. Provide the GitHub token and


### PR DESCRIPTION
## Summary
- remove `--file` from Dockerfile entrypoint so the container fetches the live dataset by default
- update README docker instructions

## Testing
- `python -m pip install -e .`
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6881f8fe23088332a78b59f1a120d621