### PR TITLE
Implement DB retention and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ python -m endolla_watcher.loop --fetch-interval 60 --update-interval 3600 \
 The site can then be served from the `site/` directory. It now features a small
 Bootstrap-based theme and an `about.html` page with project details.
 
+## Database
+
+Snapshots are stored in a SQLite database. Old records are automatically
+pruned so the database only keeps the last four weeks of history. The
+application checks the schema version when it opens the database and applies
+any pending migrations automatically. If you prefer to upgrade a database
+manually you can run:
+
+```
+python -m endolla_watcher.migrate --db endolla.db
+```
+
 ## Docker
 
 ```

--- a/src/endolla_watcher/migrate.py
+++ b/src/endolla_watcher/migrate.py
@@ -1,0 +1,25 @@
+import argparse
+from pathlib import Path
+import logging
+
+from . import storage
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", type=Path, default=Path("endolla.db"))
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+
+    setup_logging(args.debug)
+
+    conn = storage.connect(args.db)
+    conn.close()
+    logger.info("Database migrated to version %d", storage.CURRENT_SCHEMA_VERSION)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- keep only 4 weeks of snapshots in SQLite database
- add simple migration system and CLI helper
- document database pruning and migrations in README
- automatically run migrations and prune old data when connecting to the DB

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_688202d6ad9083328999cb1547dec542