### PR TITLE
Add historical chart for charger stats

### DIFF
--- a/src/endolla_watcher/loop.py
+++ b/src/endolla_watcher/loop.py
@@ -30,8 +30,9 @@ def update_once(output: Path, db: Path, rules: Rules | None = None) -> None:
     conn = storage.connect(db)
     problematic = storage.analyze_chargers(conn, rules)
     stats = storage.stats_from_db(conn)
+    history = storage.timeline_stats(conn)
     conn.close()
-    html = render(problematic, stats)
+    html = render(problematic, stats, history)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(html, encoding="utf-8")
     about_path = output.parent / "about.html"

--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -1,4 +1,5 @@
-from typing import List, Dict
+from typing import List, Dict, Any
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ INDEX_TEMPLATE = """
     <meta charset='UTF-8'>
     <title>Endolla Watcher</title>
     <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
 {navbar}
@@ -37,6 +39,12 @@ INDEX_TEMPLATE = """
     <li class="list-group-item">Currently charging: {charging}</li>
     <li class="list-group-item">Total charging events: {sessions}</li>
 </ul>
+<div class="mb-4">
+    <canvas id="historyChart" height="80"></canvas>
+</div>
+<script>
+{history_js}
+</script>
 <h2 class="mt-4">Problematic Chargers</h2>
 <div class="table-responsive">
 <table class="table table-striped">
@@ -74,18 +82,41 @@ ABOUT_TEMPLATE = """
 """
 
 
-def render(problematic: List[Dict[str, any]], stats: Dict[str, int] | None = None) -> str:
+def render(
+    problematic: List[Dict[str, Any]],
+    stats: Dict[str, int] | None = None,
+    history: List[Dict[str, Any]] | None = None,
+) -> str:
     """Return the HTML for the main report page."""
     logger.debug("Rendering %d problematic ports", len(problematic))
     if stats is None:
         stats = {"chargers": 0, "unavailable": 0, "charging": 0, "sessions": 0}
+    history_js = ""
+    if history:
+        history_js = (
+            "const historyData = "
+            + json.dumps(history)
+            + ";\n"
+            + "const labels = historyData.map(d => new Date(d.ts).toLocaleString());\n"
+            + "const ctx = document.getElementById('historyChart').getContext('2d');\n"
+            + "new Chart(ctx, {type: 'line', data: {labels, datasets: ["
+            + "{label: 'Unavailable', data: historyData.map(d => d.unavailable),"
+            + "borderColor: '#dc3545', backgroundColor: 'rgba(220,53,69,0.3)', fill: true, stack: 'usage'},"
+            + "{label: 'Charging', data: historyData.map(d => d.charging),"
+            + "borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.3)', fill: true, stack: 'usage'},"
+            + "{label: 'Total', data: historyData.map(d => d.chargers),"
+            + "borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.3)', fill: false}]},"
+            + "options: {scales: {y: {beginAtZero: true, stacked: true}}}});"
+        )
     rows = []
     for r in problematic:
         row = "<tr>" + "".join(
             f"<td>{r.get(k,'')}</td>" for k in ["location_id", "station_id", "port_id", "status", "reason"]
         ) + "</tr>"
         rows.append(row)
-    html = INDEX_TEMPLATE.format(rows="\n".join(rows), navbar=NAVBAR, **stats)
+    html = INDEX_TEMPLATE.format(
+        rows="\n".join(rows), navbar=NAVBAR, history_js=history_js, **stats
+    )
     logger.debug("Generated HTML with %d rows", len(rows))
     return html
 


### PR DESCRIPTION
## Summary
- compute per-snapshot charger statistics in `timeline_stats`
- render stacked line graph with Chart.js on index page
- show historical stats when generating site via `loop.update_once`

## Testing
- `pip install -e .`
- `python -m endolla_watcher.main --file endolla.json --output site/index.html`
- `python - <<'EOF'
from pathlib import Path
from endolla_watcher.loop import fetch_once, update_once
fetch_once(Path('test.db'), Path('endolla.json'))
update_once(Path('site/index.html'), Path('test.db'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68820c33e7208332b3ad3a4edc5672b7