### PR TITLE
Enable 15 minute history graph

### DIFF
--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -28,6 +28,7 @@ INDEX_TEMPLATE = """
     <title>Endolla Watcher</title>
     <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
 </head>
 <body>
 {navbar}
@@ -97,7 +98,7 @@ def render(
             "const historyData = "
             + json.dumps(history)
             + ";\n"
-            + "const labels = historyData.map(d => new Date(d.ts).toLocaleDateString());\n"
+            + "const labels = historyData.map(d => d.ts);\n"
             + "const ctx = document.getElementById('historyChart').getContext('2d');\n"
             + "new Chart(ctx, {type: 'line', data: {labels, datasets: ["
             + "{label: 'Unavailable', data: historyData.map(d => d.unavailable),"
@@ -106,7 +107,7 @@ def render(
             + "borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.3)', fill: true, stack: 'usage'},"
             + "{label: 'Total', data: historyData.map(d => d.chargers),"
             + "borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.3)', fill: false}]},"
-            + "options: {scales: {y: {beginAtZero: true, stacked: true}}}});"
+            + "options: {scales: {x: {type: 'time', time: {unit: 'day'}}, y: {beginAtZero: true, stacked: true}}}});"
         )
     rows = []
     for r in problematic:

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -49,9 +49,10 @@ def test_timeline_stats():
     )
 
     result = storage.timeline_stats(conn)
-    assert len(result) >= 2
-    first = result[-2]
-    second = result[-1]
+    assert len(result) == 4
+
+    first = result[1]
+    second = result[3]
 
     assert first["chargers"] == 2
     assert first["charging"] == 1


### PR DESCRIPTION
## Summary
- render Chart.js graph as a time series
- show daily ticks with 15 minute samples
- adjust database query to aggregate every 15 minutes
- update timeline test for new granularity

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688215a709908332b475cfeb0f7feb51