### PR TITLE
Fix location lookup with nested coordinates

### DIFF
--- a/src/endolla_watcher/data.py
+++ b/src/endolla_watcher/data.py
@@ -80,6 +80,15 @@ def parse_locations(data: Any) -> Dict[str, Dict[str, float]]:
             or it.get("LONGITUD")
             or it.get("longitud")
         )
+        if lat is None or lon is None:
+            coords = it.get("coordinates") or {}
+            lat = lat or coords.get("latitude") or coords.get("lat")
+            lon = lon or coords.get("longitude") or coords.get("lon")
+        if lat is None or lon is None:
+            address = it.get("address") or {}
+            coords = address.get("coordinates") or {}
+            lat = lat or coords.get("latitude") or coords.get("lat")
+            lon = lon or coords.get("longitude") or coords.get("lon")
         if loc_id is None or lat is None or lon is None:
             continue
         try:

--- a/tests/test_parse_locations.py
+++ b/tests/test_parse_locations.py
@@ -1,0 +1,15 @@
+import endolla_watcher.data as data
+
+
+def test_parse_locations_nested_coords():
+    sample = {
+        "locations": [
+            {"id": "L1", "coordinates": {"latitude": 1.1, "longitude": 2.2}},
+            {"id": "L2", "address": {"coordinates": {"latitude": 3.3, "longitude": 4.4}}},
+        ]
+    }
+    result = data.parse_locations(sample)
+    assert result == {
+        "L1": {"lat": 1.1, "lon": 2.2},
+        "L2": {"lat": 3.3, "lon": 4.4},
+    }


### PR DESCRIPTION
## Summary
- support nested coordinate fields when parsing location data
- test nested coordinates in `parse_locations`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688278c3c308833282a1aedb1f59e2f2