### PR TITLE
Add daily charge stats and clarify port counts

### DIFF
--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -35,10 +35,11 @@ INDEX_TEMPLATE = """
 <div class="container py-4">
 <h1 class="mb-4">Network Overview</h1>
 <ul class="list-group mb-4">
-    <li class="list-group-item">Total chargers: {chargers}</li>
-    <li class="list-group-item">Unavailable chargers: {unavailable}</li>
+    <li class="list-group-item">Total ports: {chargers}</li>
+    <li class="list-group-item">Unavailable ports: {unavailable}</li>
     <li class="list-group-item">Currently charging: {charging}</li>
     <li class="list-group-item">Total charging events: {sessions}</li>
+    <li class="list-group-item">Charges today: {charges_today}</li>
     <li class="list-group-item">Short sessions (<5 min): {short_sessions}</li>
     <li class="list-group-item">Avg session (24h): {avg_session_min:.1f} min</li>
 </ul>
@@ -134,6 +135,7 @@ def render(
             "unavailable": 0,
             "charging": 0,
             "sessions": 0,
+            "charges_today": 0,
             "short_sessions": 0,
             "avg_session_min": 0.0,
         }

--- a/src/endolla_watcher/stats.py
+++ b/src/endolla_watcher/stats.py
@@ -37,4 +37,5 @@ def from_records(records: Iterable[Dict[str, Any]]) -> Dict[str, float]:
         "sessions": sessions,
         "avg_session_min": avg,
         "short_sessions": short_sessions,
+        "charges_today": 0,
     }

--- a/src/endolla_watcher/storage.py
+++ b/src/endolla_watcher/storage.py
@@ -348,6 +348,15 @@ def stats_from_db(conn: sqlite3.Connection) -> Dict[str, float]:
             if start >= since:
                 durations.append(dur)
     stats["avg_session_min"] = sum(durations) / len(durations) if durations else 0.0
+
+    # Count charging sessions that started since midnight today
+    today = datetime.now().astimezone().replace(hour=0, minute=0, second=0, microsecond=0)
+    charges_today = 0
+    for events in history.values():
+        for start, end, _ in _session_records(events):
+            if start >= today:
+                charges_today += 1
+    stats["charges_today"] = charges_today
     return stats
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -38,6 +38,7 @@ def test_average_session_last_day():
     stats = storage.stats_from_db(conn)
     assert stats["avg_session_min"] == 60
     assert stats["short_sessions"] == 0
+    assert stats["charges_today"] == 1
     conn.close()
 
 
@@ -61,4 +62,5 @@ def test_count_short_sessions():
 
     stats = storage.stats_from_db(conn)
     assert stats["short_sessions"] == 1
+    assert stats["charges_today"] == 1
     conn.close()


### PR DESCRIPTION
## Summary
- rename counters on the main page to reference ports
- display charges started today in the statistics
- compute `charges_today` in storage.stats_from_db
- adjust default stats and tests for the new field

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688379a5e340833289adc43e76f6f276