### PR TITLE
Enhance report with rule stats and history

### DIFF
--- a/src/endolla_watcher/loop.py
+++ b/src/endolla_watcher/loop.py
@@ -36,14 +36,16 @@ def update_once(
     logger.debug("Updating report from db=%s", db)
     start = time.monotonic()
     conn = storage.connect(db)
-    problematic = storage.analyze_chargers(conn, rules)
+    problematic, rule_counts = storage.analyze_chargers(conn, rules)
     stats = storage.stats_from_db(conn)
-    history = storage.timeline_stats(conn)
+    history = storage.timeline_stats(conn, rules)
     db_size = db.stat().st_size / (1024 * 1024)
     html = render(
         problematic,
         stats,
         history,
+        rule_counts,
+        rules,
         updated=datetime.now().astimezone().isoformat(timespec="seconds"),
         db_size=db_size,
         elapsed=time.monotonic() - start,

--- a/src/endolla_watcher/main.py
+++ b/src/endolla_watcher/main.py
@@ -42,6 +42,8 @@ def main() -> None:
     html = render(
         problematic,
         stats,
+        rule_counts={},
+        rules=None,
         updated=datetime.now().astimezone().isoformat(timespec="seconds"),
         elapsed=time.monotonic() - start,
         locations=locations,

--- a/tests/test_rule_counts.py
+++ b/tests/test_rule_counts.py
@@ -1,0 +1,52 @@
+import endolla_watcher.storage as storage
+from endolla_watcher.rules import Rules
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def test_rule_counts():
+    conn = storage.connect(Path(":memory:"))
+    now = datetime.now(timezone.utc)
+
+    # Port 1 - unused
+    old = now - timedelta(days=1)
+    storage.save_snapshot(
+        conn,
+        [{"location_id": "L1", "station_id": "S1", "port_id": "P1", "status": "AVAILABLE", "last_updated": old.isoformat()}],
+        ts=old,
+    )
+
+    # Port 2 - only short session
+    start = now - timedelta(days=1)
+    end = start + timedelta(minutes=3)
+    storage.save_snapshot(
+        conn,
+        [{"location_id": "L2", "station_id": "S2", "port_id": "P1", "status": "IN_USE", "last_updated": start.isoformat()}],
+        ts=start,
+    )
+    storage.save_snapshot(
+        conn,
+        [{"location_id": "L2", "station_id": "S2", "port_id": "P1", "status": "AVAILABLE", "last_updated": end.isoformat()}],
+        ts=end,
+    )
+
+    # Port 3 - unavailable for long time
+    start3 = now - timedelta(hours=8)
+    storage.save_snapshot(
+        conn,
+        [{"location_id": "L3", "station_id": "S3", "port_id": "P1", "status": "OUT_OF_ORDER", "last_updated": start3.isoformat()}],
+        ts=start3,
+    )
+    storage.save_snapshot(
+        conn,
+        [{"location_id": "L3", "station_id": "S3", "port_id": "P1", "status": "OUT_OF_ORDER", "last_updated": now.isoformat()}],
+        ts=now,
+    )
+
+    rules = Rules(unused_days=1, long_session_days=1, long_session_min=5, unavailable_hours=6)
+    problematic, counts = storage.analyze_chargers(conn, rules, now=now)
+    assert counts["unused"] == 1
+    assert counts["no_long"] == 2
+    assert counts["unavailable"] == 1
+    assert len(problematic) == 3
+    conn.close()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -57,9 +57,11 @@ def test_timeline_stats():
     assert first["chargers"] == 2
     assert first["charging"] == 1
     assert first["unavailable"] == 1
+    assert first["problematic"] == 0
 
     assert second["chargers"] == 2
     assert second["charging"] == 1
     assert second["unavailable"] == 0
+    assert second["problematic"] == 0
 
     conn.close()


### PR DESCRIPTION
## Summary
- track problematic rule counts when analysing chargers
- expose counts and thresholds in the rendered page
- show problematic counts in the weekly history chart
- provide new test coverage for rule counting and extended timeline stats

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688775f6ddf083329c575ddf71bec4bb