### PR TITLE
Split history chart and add problematic page

### DIFF
--- a/src/endolla_watcher/main.py
+++ b/src/endolla_watcher/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from .data import fetch_data, fetch_locations, parse_usage
 from .analyze import analyze
-from .render import render, render_about
+from .render import render, render_about, render_problematic
 from .stats import from_records
 from .logging_utils import setup_logging
 
@@ -42,6 +42,8 @@ def main() -> None:
     html = render(
         problematic,
         stats,
+        history=None,
+        daily=None,
         rule_counts={},
         rules=None,
         updated=datetime.now().astimezone().isoformat(timespec="seconds"),
@@ -53,6 +55,14 @@ def main() -> None:
     # Write the about page alongside the main report
     about_path = args.output.parent / "about.html"
     about_path.write_text(render_about(), encoding="utf-8")
+    prob_path = args.output.parent / "problematic.html"
+    prob_page = render_problematic(
+        problematic,
+        updated=datetime.now().astimezone().isoformat(timespec="seconds"),
+        elapsed=time.monotonic() - start,
+        locations=locations,
+    )
+    prob_path.write_text(prob_page, encoding="utf-8")
     logger.info("Wrote report to %s", args.output)
 
 

--- a/src/endolla_watcher/render.py
+++ b/src/endolla_watcher/render.py
@@ -13,6 +13,7 @@ NAVBAR = """
     <a class="navbar-brand" href="index.html">Endolla Watcher</a>
     <div class="collapse navbar-collapse">
       <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="problematic.html">Problematic</a></li>
         <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
       </ul>
     </div>
@@ -51,22 +52,22 @@ INDEX_TEMPLATE = """
     <li class="list-group-item">Unavailable > {unavailable_hours}h: {unavailable_rule}</li>
 </ul>
 <div class="mb-4">
-    <canvas id="historyChart" height="80"></canvas>
+    <canvas id="unusedChart" height="60"></canvas>
+</div>
+<div class="mb-4">
+    <canvas id="chargesChart" height="60"></canvas>
+</div>
+<div class="mb-4">
+    <canvas id="problematicChart" height="60"></canvas>
+</div>
+<div class="mb-4">
+    <canvas id="chargingChart" height="60"></canvas>
 </div>
 <script>
 {history_js}
 </script>
 <h2 class="mt-4">Problematic Chargers</h2>
-<div class="table-responsive">
-<table class="table table-striped">
-    <thead class="table-dark">
-        <tr><th>Location</th><th>Station</th><th>Port</th><th>Status</th><th>Reason</th></tr>
-    </thead>
-    <tbody>
-        {rows}
-    </tbody>
-</table>
-</div>
+<p><a href="problematic.html">View {problematic_count} chargers</a></p>
 <div class="text-muted small mt-4">
     <p>Page last updated: {updated}</p>
     <p>DB size: {db_size:.1f} MB</p>
@@ -104,6 +105,40 @@ CHARGER_TEMPLATE = """
 </html>
 """
 
+# Template for a separate page listing problematic chargers
+PROBLEMATIC_TEMPLATE = """
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <title>Problematic Chargers</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+{navbar}
+<div class="container py-4">
+<h1 class="mb-4">Problematic Chargers</h1>
+<div class="table-responsive">
+<table class="table table-striped">
+    <thead class="table-dark">
+        <tr><th>Location</th><th>Station</th><th>Port</th><th>Status</th><th>Reason</th></tr>
+    </thead>
+    <tbody>
+        {rows}
+    </tbody>
+</table>
+</div>
+<p><a href="index.html">Back to index</a></p>
+<div class="text-muted small mt-4">
+    <p>Page last updated: {updated}</p>
+    <p>DB size: {db_size:.1f} MB</p>
+    <p>Processed in {elapsed:.2f} s</p>
+</div>
+</div>
+</body>
+</html>
+"""
+
 # Template for the about page
 ABOUT_TEMPLATE = """
 <!DOCTYPE html>
@@ -129,6 +164,7 @@ def render(
     problematic: List[Dict[str, Any]],
     stats: Dict[str, float] | None = None,
     history: List[Dict[str, Any]] | None = None,
+    daily: List[Dict[str, Any]] | None = None,
     rule_counts: Dict[str, int] | None = None,
     rules: Rules | None = None,
     updated: str | None = None,
@@ -152,29 +188,75 @@ def render(
         rule_counts = {"unused": 0, "no_long": 0, "unavailable": 0}
     history_js = ""
     if history:
-        history_js = (
-            "const historyData = "
-            + json.dumps(history)
-            + ";\n"
-            + "const labels = historyData.map(d => d.ts);\n"
-            + "const ctx = document.getElementById('historyChart').getContext('2d');\n"
-            + "new Chart(ctx, {type: 'line', data: {labels, datasets: ["
-            + "{label: 'Unavailable', data: historyData.map(d => d.unavailable),"
-            + "borderColor: '#dc3545', backgroundColor: 'rgba(220,53,69,0.3)', fill: true, stack: 'usage'},"
-            + "{label: 'Unused >1d', data: historyData.map(d => d.unused_1),"
-            + "borderColor: '#ffc107', backgroundColor: 'rgba(255,193,7,0.3)', fill: true, stack: 'usage'},"
-            + "{label: 'Unused >2d', data: historyData.map(d => d.unused_2),"
-            + "borderColor: '#6f42c1', backgroundColor: 'rgba(111,66,193,0.3)', fill: true, stack: 'usage'},"
-            + "{label: 'Unused >7d', data: historyData.map(d => d.unused_7),"
-            + "borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.3)', fill: true, stack: 'usage'},"
-            + "{label: 'Problematic', data: historyData.map(d => d.problematic),"
-            + "borderColor: '#fd7e14', backgroundColor: 'rgba(253,126,20,0.3)', fill: true, stack: 'usage'},"
-            + "{label: 'Charging', data: historyData.map(d => d.charging),"
-            + "borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.3)', fill: true, stack: 'usage'}]},"
-            + "options: {scales: {x: {type: 'time', time: {unit: 'day'}}, y: {beginAtZero: true, stacked: true}}}});"
+        history_js += "const historyData = " + json.dumps(history) + "\n"
+        history_js += "const labels = historyData.map(d => d.ts);\n"
+        history_js += (
+            "new Chart(document.getElementById('unusedChart').getContext('2d'), {"+
+            "type: 'line', data: {labels, datasets: ["+
+            "{label: 'Unused >1d', data: historyData.map(d => d.unused_1),"+
+            "borderColor: '#ffc107', backgroundColor: 'rgba(255,193,7,0.3)', fill: true},"+
+            "{label: 'Unused >2d', data: historyData.map(d => d.unused_2),"+
+            "borderColor: '#6f42c1', backgroundColor: 'rgba(111,66,193,0.3)', fill: true},"+
+            "{label: 'Unused >7d', data: historyData.map(d => d.unused_7),"+
+            "borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.3)', fill: true}]},"+
+            "options: {scales: {x: {type: 'time', time: {unit: 'day'}}, y: {beginAtZero: true}}}});\n"
         )
-    rows = []
-    for r in problematic:
+        history_js += (
+            "new Chart(document.getElementById('problematicChart').getContext('2d'), {"+
+            "type: 'line', data: {labels, datasets: ["+
+            "{label: 'Problematic', data: historyData.map(d => d.problematic),"+
+            "borderColor: '#fd7e14', backgroundColor: 'rgba(253,126,20,0.3)', fill: true}]},"+
+            "options: {scales: {x: {type: 'time', time: {unit: 'day'}}, y: {beginAtZero: true}}}});\n"
+        )
+        history_js += (
+            "new Chart(document.getElementById('chargingChart').getContext('2d'), {"+
+            "type: 'line', data: {labels, datasets: ["+
+            "{label: 'Charging', data: historyData.map(d => d.charging),"+
+            "borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.3)', fill: true}]},"+
+            "options: {scales: {x: {type: 'time', time: {unit: 'day'}}, y: {beginAtZero: true}}}});\n"
+        )
+    if daily:
+        history_js += "const dailyData = " + json.dumps(daily) + "\n"
+        history_js += "const dailyLabels = dailyData.map(d => d.day);\n"
+        history_js += (
+            "new Chart(document.getElementById('chargesChart').getContext('2d'), {"+
+            "type: 'bar', data: {labels: dailyLabels, datasets: ["+
+            "{label: 'Charges', data: dailyData.map(d => d.sessions),"+
+            "backgroundColor: '#0d6efd'}]},"+
+            "options: {scales: {y: {beginAtZero: true}}}});\n"
+        )
+    html = INDEX_TEMPLATE.format(
+        navbar=NAVBAR,
+        history_js=history_js,
+        problematic_count=len(problematic),
+        updated=updated or "N/A",
+        db_size=(db_size if db_size is not None else 0.0),
+        elapsed=(elapsed if elapsed is not None else 0.0),
+        unused=rule_counts.get("unused", 0),
+        no_long=rule_counts.get("no_long", 0),
+        unavailable_rule=rule_counts.get("unavailable", 0),
+        unused_days=(rules.unused_days if rules else 0),
+        long_session_min=(rules.long_session_min if rules else 0),
+        long_session_days=(rules.long_session_days if rules else 0),
+        unavailable_hours=(rules.unavailable_hours if rules else 0),
+        **stats,
+    )
+    logger.debug("Generated index HTML with %d problematic entries", len(problematic))
+    return html
+
+
+def render_about() -> str:
+    """Return the HTML for the about page."""
+    return ABOUT_TEMPLATE.format(navbar=NAVBAR)
+
+
+def _render_problematic_rows(
+    entries: List[Dict[str, Any]],
+    locations: Dict[str, Dict[str, float]] | None = None,
+) -> str:
+    """Return HTML table rows for problematic chargers."""
+    rows: List[str] = []
+    for r in entries:
         loc = r.get("location_id") or ""
         sta = r.get("station_id") or ""
         url = f"charger_{loc}_{sta}.html"
@@ -191,31 +273,28 @@ def render(
             f"<td>{r.get('status','')}</td>",
             f"<td>{r.get('reason','')}</td>",
         ]
-        row = "<tr>" + "".join(cells) + "</tr>"
-        rows.append(row)
-    html = INDEX_TEMPLATE.format(
-        rows="\n".join(rows),
+        rows.append("<tr>" + "".join(cells) + "</tr>")
+    return "\n".join(rows)
+
+
+def render_problematic(
+    problematic: List[Dict[str, Any]],
+    updated: str | None = None,
+    db_size: float | None = None,
+    elapsed: float | None = None,
+    locations: Dict[str, Dict[str, float]] | None = None,
+) -> str:
+    """Return the HTML page listing problematic chargers."""
+    rows = _render_problematic_rows(problematic, locations)
+    html = PROBLEMATIC_TEMPLATE.format(
         navbar=NAVBAR,
-        history_js=history_js,
+        rows=rows,
         updated=updated or "N/A",
         db_size=(db_size if db_size is not None else 0.0),
         elapsed=(elapsed if elapsed is not None else 0.0),
-        unused=rule_counts.get("unused", 0),
-        no_long=rule_counts.get("no_long", 0),
-        unavailable_rule=rule_counts.get("unavailable", 0),
-        unused_days=(rules.unused_days if rules else 0),
-        long_session_min=(rules.long_session_min if rules else 0),
-        long_session_days=(rules.long_session_days if rules else 0),
-        unavailable_hours=(rules.unavailable_hours if rules else 0),
-        **stats,
     )
-    logger.debug("Generated HTML with %d rows", len(rows))
+    logger.debug("Generated problematic page with %d rows", len(problematic))
     return html
-
-
-def render_about() -> str:
-    """Return the HTML for the about page."""
-    return ABOUT_TEMPLATE.format(navbar=NAVBAR)
 
 
 def render_charger(


### PR DESCRIPTION
## Summary
- split history chart into four separate graphs
- move detailed table to `problematic.html`
- generate the new page in both main and loop flows
- track sessions per day in storage for the new chart

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c3fd1cb48332992b78b45f7d7779