### PR TITLE
Add database maintenance utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ manually you can run:
 python -m endolla_watcher.migrate --db endolla.db
 ```
 
+To review the current size and reclaim unused space you can run:
+
+```
+python -m endolla_watcher.db --db endolla.db --compress
+```
+
+Omit `--compress` to only display basic database statistics.
+
 ## Docker
 
 ```

--- a/src/endolla_watcher/db.py
+++ b/src/endolla_watcher/db.py
@@ -1,0 +1,45 @@
+import argparse
+import logging
+from pathlib import Path
+
+from . import storage
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect or compress the database")
+    parser.add_argument("--db", type=Path, default=Path("endolla.db"))
+    parser.add_argument(
+        "--compress",
+        action="store_true",
+        help="Run VACUUM to reclaim free space",
+    )
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+
+    setup_logging(args.debug)
+
+    conn = storage.connect(args.db)
+    stats = storage.db_stats(conn)
+    logger.info(
+        "rows=%d size=%.1fMB free=%.1fMB",
+        stats["rows"],
+        stats["size_bytes"] / (1024 * 1024),
+        stats["freelist"] * stats["page_size"] / (1024 * 1024),
+    )
+    if args.compress:
+        before = stats["size_bytes"]
+        storage.compress_db(conn)
+        stats = storage.db_stats(conn)
+        logger.info(
+            "compressed from %.1fMB to %.1fMB",
+            before / (1024 * 1024),
+            stats["size_bytes"] / (1024 * 1024),
+        )
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_db_management.py
+++ b/tests/test_db_management.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+import endolla_watcher.storage as storage
+
+
+def test_db_stats_and_compress(tmp_path):
+    db = tmp_path / "test.db"
+    conn = storage.connect(db)
+
+    now = datetime.now().astimezone()
+    rows = [
+        (
+            now.isoformat(),
+            "loc",
+            "sta",
+            str(i),
+            "IN_USE",
+            None,
+        )
+        for i in range(500)
+    ]
+    conn.executemany(
+        "INSERT INTO port_status (ts, location_id, station_id, port_id, status, last_updated) VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+    stats = storage.db_stats(conn)
+    assert stats["rows"] == 500
+    size_before = stats["size_bytes"]
+
+    conn.execute("DELETE FROM port_status")
+    conn.commit()
+    size_after_delete = storage.db_stats(conn)["size_bytes"]
+    assert size_after_delete >= size_before
+
+    storage.compress_db(conn)
+    size_after_compress = storage.db_stats(conn)["size_bytes"]
+    assert size_after_compress < size_after_delete
+
+    conn.close()


### PR DESCRIPTION
## Summary
- add `db_stats` and `compress_db` helpers for SQLite maintenance
- provide `endolla_watcher.db` CLI to inspect and compact the database
- document database maintenance commands
- test compression behaviour

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python -m endolla_watcher.db --db tmp.db --compress`


------
https://chatgpt.com/codex/tasks/task_e_689998a57c0c83329d9a120139aec0a4